### PR TITLE
Link between objects with UUID rather than object ref

### DIFF
--- a/common/src/main/java/cmpe277/project/skibuddy/common/Event.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/common/Event.java
@@ -24,9 +24,9 @@ public interface Event {
 
     void setEnd(DateTime end);
 
-    User getHost();
+    UUID getHostId();
 
-    void setHost(User host);
+    void setHostId(UUID host);
 
     UUID getEventID();
 

--- a/common/src/main/java/cmpe277/project/skibuddy/common/NotAuthenticatedException.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/common/NotAuthenticatedException.java
@@ -1,0 +1,7 @@
+package cmpe277.project.skibuddy.common;
+
+/**
+ * Created by eh on 11/29/2015.
+ */
+public class NotAuthenticatedException extends Exception {
+}

--- a/common/src/main/java/cmpe277/project/skibuddy/common/Run.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/common/Run.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Created by eh on 11/29/2015.
@@ -19,17 +20,17 @@ public interface Run {
 
     void setEnd(DateTime end);
 
-    User getUser();
+    UUID getUserId();
 
-    void setUser(User user);
+    void setUserId(UUID user);
 
-    Event getEvent();
+    UUID getEventId();
 
-    void setEvent(Event event);
+    void setEventId(UUID event);
 
-    int getDistance();
+    double getDistance();
 
-    int getTopSpeed();
+    double getTopSpeed();
 
     Duration getTotalTime();
 }

--- a/common/src/main/java/cmpe277/project/skibuddy/common/User.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/common/User.java
@@ -29,8 +29,6 @@ public interface User {
 
     void setPosition(Location position);
 
-    List<Run> getRuns();
-
     double getTotalDistance();
 
     Duration getTotalTime();

--- a/common/src/main/java/cmpe277/project/skibuddy/server/MockServer.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/server/MockServer.java
@@ -14,6 +14,7 @@ import cmpe277.project.skibuddy.common.Event;
 import cmpe277.project.skibuddy.common.EventParticipant;
 import cmpe277.project.skibuddy.common.Location;
 import cmpe277.project.skibuddy.common.LocationListener;
+import cmpe277.project.skibuddy.common.NotAuthenticatedException;
 import cmpe277.project.skibuddy.common.ParticipationStatus;
 import cmpe277.project.skibuddy.common.Run;
 import cmpe277.project.skibuddy.common.User;
@@ -113,7 +114,7 @@ public class MockServer implements Server {
                 Run run1 = new PojoRun();
                 run1.setStart(new DateTime(2015,10,23,19,43));
                 run1.setEnd(new DateTime(2015, 10, 23, 19, 54));
-                run1.setUser(getRandomUser());
+                run1.setUserId(UUID.randomUUID());
                 runs.add(run1);
                 callback.postResult(runs);
                 invokeCallback(callback);
@@ -137,6 +138,23 @@ public class MockServer implements Server {
     }
 
     @Override
+    public void getEvent(UUID eventID, final ServerCallback<Event> callback) {
+        doAfterRandomTimeout(new Runnable() {
+            @Override
+            public void run() {
+                Event someEvent = new PojoEvent();
+                someEvent.setName("Go Skiing");
+                someEvent.setStart(new DateTime(2016, 1, 2, 10, 0, 0));
+                someEvent.setEnd(new DateTime(2016, 1, 2, 19, 0, 0));
+                someEvent.setDescription("Let's go skiing in Tahoe!");
+                someEvent.setHostId(UUID.randomUUID());
+                callback.postResult(someEvent);
+                invokeCallback(callback);
+            }
+        });
+    }
+
+    @Override
     public void getEvents(final ServerCallback<List<Event>> callback) {
         doAfterRandomTimeout(new Runnable() {
             @Override
@@ -146,7 +164,7 @@ public class MockServer implements Server {
                 someEvent.setStart(new DateTime(2016, 1, 2, 10, 0, 0));
                 someEvent.setEnd(new DateTime(2016, 1, 2, 19, 0, 0));
                 someEvent.setDescription("Let's go skiing in Tahoe!");
-                someEvent.setHost(getRandomUser());
+                someEvent.setHostId(UUID.randomUUID());
                 List<Event> events = new LinkedList<Event>();
                 events.add(someEvent);
                 callback.postResult(events);
@@ -221,5 +239,10 @@ public class MockServer implements Server {
     @Override
     public void unregisterLocationListener(LocationListener listener) {
 
+    }
+
+    @Override
+    public User getAuthenticatedUser() throws NotAuthenticatedException {
+        return getRandomUser();
     }
 }

--- a/common/src/main/java/cmpe277/project/skibuddy/server/PojoEvent.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/server/PojoEvent.java
@@ -5,7 +5,6 @@ import org.joda.time.DateTime;
 import java.util.UUID;
 
 import cmpe277.project.skibuddy.common.Event;
-import cmpe277.project.skibuddy.common.User;
 
 class PojoEvent implements Event {
 	private UUID eventID;
@@ -13,22 +12,23 @@ class PojoEvent implements Event {
 	private String description;
 	private DateTime start;
 	private DateTime end;
-	private User host;
+	private UUID hostId;
 
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 
-		PojoEvent event = (PojoEvent) o;
+		PojoEvent pojoEvent = (PojoEvent) o;
 
-		if (eventID != null ? !eventID.equals(event.eventID) : event.eventID != null) return false;
-		if (name != null ? !name.equals(event.name) : event.name != null) return false;
-		if (description != null ? !description.equals(event.description) : event.description != null)
+		if (eventID != null ? !eventID.equals(pojoEvent.eventID) : pojoEvent.eventID != null)
 			return false;
-		if (start != null ? !start.equals(event.start) : event.start != null) return false;
-		if (end != null ? !end.equals(event.end) : event.end != null) return false;
-		return !(host != null ? !host.equals(event.host) : event.host != null);
+		if (name != null ? !name.equals(pojoEvent.name) : pojoEvent.name != null) return false;
+		if (description != null ? !description.equals(pojoEvent.description) : pojoEvent.description != null)
+			return false;
+		if (start != null ? !start.equals(pojoEvent.start) : pojoEvent.start != null) return false;
+		if (end != null ? !end.equals(pojoEvent.end) : pojoEvent.end != null) return false;
+		return !(hostId != null ? !hostId.equals(pojoEvent.hostId) : pojoEvent.hostId != null);
 
 	}
 
@@ -39,7 +39,7 @@ class PojoEvent implements Event {
 		result = 31 * result + (description != null ? description.hashCode() : 0);
 		result = 31 * result + (start != null ? start.hashCode() : 0);
 		result = 31 * result + (end != null ? end.hashCode() : 0);
-		result = 31 * result + (host != null ? host.hashCode() : 0);
+		result = 31 * result + (hostId != null ? hostId.hashCode() : 0);
 		return result;
 	}
 
@@ -84,13 +84,13 @@ class PojoEvent implements Event {
 	}
 
 	@Override
-	public User getHost() {
-		return host;
+	public UUID getHostId() {
+		return hostId;
 	}
 
 	@Override
-	public void setHost(User host) {
-		this.host = host;
+	public void setHostId(UUID hostId) {
+		this.hostId = hostId;
 	}
 
 	@Override

--- a/common/src/main/java/cmpe277/project/skibuddy/server/PojoRun.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/server/PojoRun.java
@@ -5,6 +5,7 @@ import org.joda.time.Duration;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import cmpe277.project.skibuddy.common.Event;
 import cmpe277.project.skibuddy.common.Location;
@@ -15,21 +16,21 @@ class PojoRun implements Run {
 	private List<Location> track = new LinkedList<Location>();
 	private DateTime start;
 	private DateTime end;
-	private User user;
-	private Event event;
+	private UUID userId;
+	private UUID eventId;
 
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 
-		PojoRun run = (PojoRun) o;
+		PojoRun pojoRun = (PojoRun) o;
 
-		if (track != null ? !track.equals(run.track) : run.track != null) return false;
-		if (start != null ? !start.equals(run.start) : run.start != null) return false;
-		if (end != null ? !end.equals(run.end) : run.end != null) return false;
-		if (user != null ? !user.equals(run.user) : run.user != null) return false;
-		return !(event != null ? !event.equals(run.event) : run.event != null);
+		if (track != null ? !track.equals(pojoRun.track) : pojoRun.track != null) return false;
+		if (start != null ? !start.equals(pojoRun.start) : pojoRun.start != null) return false;
+		if (end != null ? !end.equals(pojoRun.end) : pojoRun.end != null) return false;
+		if (userId != null ? !userId.equals(pojoRun.userId) : pojoRun.userId != null) return false;
+		return !(eventId != null ? !eventId.equals(pojoRun.eventId) : pojoRun.eventId != null);
 
 	}
 
@@ -38,8 +39,8 @@ class PojoRun implements Run {
 		int result = track != null ? track.hashCode() : 0;
 		result = 31 * result + (start != null ? start.hashCode() : 0);
 		result = 31 * result + (end != null ? end.hashCode() : 0);
-		result = 31 * result + (user != null ? user.hashCode() : 0);
-		result = 31 * result + (event != null ? event.hashCode() : 0);
+		result = 31 * result + (userId != null ? userId.hashCode() : 0);
+		result = 31 * result + (eventId != null ? eventId.hashCode() : 0);
 		return result;
 	}
 
@@ -69,37 +70,37 @@ class PojoRun implements Run {
 	}
 
 	@Override
-	public User getUser() {
-		return user;
+	public UUID getUserId() {
+		return userId;
 	}
 
 	@Override
-	public void setUser(User user) {
-		this.user = user;
+	public void setUserId(UUID userId) {
+		this.userId = userId;
 	}
 
 	@Override
-	public Event getEvent() {
-		return event;
+	public UUID getEventId() {
+		return eventId;
 	}
 
 	@Override
-	public void setEvent(Event event) {
-		this.event = event;
+	public void setEventId(UUID eventId) {
+		this.eventId = eventId;
 	}
 
 	@Override
-	public int getDistance() {
-		throw new UnsupportedOperationException();
+	public double getDistance() {
+		return 1423.14;
 	}
 
 	@Override
-	public int getTopSpeed() {
-		throw new UnsupportedOperationException();
+	public double getTopSpeed() {
+		return 52.12;
 	}
 
 	@Override
 	public Duration getTotalTime() {
-		throw new UnsupportedOperationException();
+		return Duration.standardSeconds(512);
 	}
 }

--- a/common/src/main/java/cmpe277/project/skibuddy/server/PojoUser.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/server/PojoUser.java
@@ -2,12 +2,9 @@ package cmpe277.project.skibuddy.server;
 
 import org.joda.time.Duration;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.UUID;
 
 import cmpe277.project.skibuddy.common.Location;
-import cmpe277.project.skibuddy.common.Run;
 import cmpe277.project.skibuddy.common.User;
 
 class PojoUser implements User {
@@ -16,7 +13,6 @@ class PojoUser implements User {
 	private String profilePictureURL;
 	private UUID id;
 	private Location position;
-	private List<Run> runs = new LinkedList<Run>();
 
 	@Override
 	public String getName() {
@@ -66,11 +62,6 @@ class PojoUser implements User {
 	@Override
 	public void setPosition(Location position) {
 		this.position = position;
-	}
-
-	@Override
-	public List<Run> getRuns() {
-		return runs;
 	}
 
 	@Override

--- a/common/src/main/java/cmpe277/project/skibuddy/server/Server.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/server/Server.java
@@ -7,6 +7,7 @@ import cmpe277.project.skibuddy.common.Event;
 import cmpe277.project.skibuddy.common.EventParticipant;
 import cmpe277.project.skibuddy.common.Location;
 import cmpe277.project.skibuddy.common.LocationListener;
+import cmpe277.project.skibuddy.common.NotAuthenticatedException;
 import cmpe277.project.skibuddy.common.Run;
 import cmpe277.project.skibuddy.common.User;
 
@@ -16,6 +17,12 @@ public interface Server {
 	 * Returns the user object of the user that is logging in (if successful). If unsuccessful returns null.
 	 */
 	void authenticateUser(String authentication_token, ServerCallback<User> callback);
+
+	/**
+	 * Returns the currently logged in user.
+	 * @throws cmpe277.project.skibuddy.common.NotAuthenticatedException If no user currently logged in
+	 */
+	User getAuthenticatedUser() throws NotAuthenticatedException;
 
 	/**
 	 * Returns the requested user. If unsuccessful returns null.
@@ -42,6 +49,11 @@ public interface Server {
 	 * Persists the run on the server.
 	 */
 	void storeRun(Run run);
+
+	/**
+	 * Fetches the specified event. Returns null if the event couldn't be found.
+	 */
+	void getEvent(UUID eventID, ServerCallback<Event> callback);
 
 	/**
 	 * Returns all events that the current user is involved with (either as a participant, host, or invitee).


### PR DESCRIPTION
Prevents the app from having to load the full object model as soon as it starts.

This way activities can request the objects they need using the UUID. 
