### PR TITLE
Changed name of the parse class

### DIFF
--- a/common/src/main/java/cmpe277/project/skibuddy/server/parseobjects/ParseUser.java
+++ b/common/src/main/java/cmpe277/project/skibuddy/server/parseobjects/ParseUser.java
@@ -13,7 +13,7 @@ import cmpe277.project.skibuddy.common.User;
 /**
  * Created by eh on 12/1/2015.
  */
-@ParseClassName("User")
+@ParseClassName("SkiBuddyUser")
 public class ParseUser extends ParseObject implements User {
     public static final String NAME_FIELD = "NAME";
     public static final String TAGLINE_FIELD = "TAGLINE";


### PR DESCRIPTION
Apparently 'User' is a builtin for Parse
